### PR TITLE
Flag expanded variants containing ambiguous calls.

### DIFF
--- a/Java/PlatinumGenomes-variant-transformation/pom.xml
+++ b/Java/PlatinumGenomes-variant-transformation/pom.xml
@@ -13,6 +13,12 @@
       <artifactId>google-genomics-dataflow</artifactId>
       <version>v1beta2-0.8</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -36,7 +42,7 @@
           <instructions>
             <!-- Embed all dependencies -->
             <Embed-Transitive>true</Embed-Transitive>
-            <Embed-Dependency>*;scope=compile|system|runtime;inline=true</Embed-Dependency>
+            <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
           </instructions>
         </configuration>
       </plugin>

--- a/Java/PlatinumGenomes-variant-transformation/pom.xml
+++ b/Java/PlatinumGenomes-variant-transformation/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>com.google.cloud.genomics</groupId>
       <artifactId>google-genomics-dataflow</artifactId>
-      <version>v1beta2-0.6</version>
+      <version>v1beta2-0.8</version>
     </dependency>
   </dependencies>
 

--- a/Java/PlatinumGenomes-variant-transformation/src/main/java/com/google/cloud/genomics/examples/TransformNonVariantSegmentData.java
+++ b/Java/PlatinumGenomes-variant-transformation/src/main/java/com/google/cloud/genomics/examples/TransformNonVariantSegmentData.java
@@ -98,8 +98,8 @@ public class TransformNonVariantSegmentData {
 
     void setOutputTable(String value);
 
-    @Description("A file path to an optional list of newline-separated callset names to exclude "
-        + "from the results of this pipeline.")
+    @Description("A local file path to an optional list of newline-separated callset names "
+        + "to exclude from the results of this pipeline.")
     String getCallSetNamesToExclude();
 
     void setCallSetNamesToExclude(String value);
@@ -171,7 +171,8 @@ public class TransformNonVariantSegmentData {
                   (v.getAlternateBases() == null) ? new ArrayList<String>() : v.getAlternateBases())
               .set("names", (v.getNames() == null) ? new ArrayList<String>() : v.getNames())
               .set("filter", (v.getFilter() == null) ? new ArrayList<String>() : v.getFilter())
-              .set("quality", v.getQuality()).set("call", calls)
+              .set("quality", v.getQuality())
+              .set("call", calls)
               .set(HAS_AMBIGUOUS_CALLS_FIELD, v.getInfo().get(HAS_AMBIGUOUS_CALLS_FIELD).get(0));
 
       c.output(row);
@@ -223,9 +224,8 @@ public class TransformNonVariantSegmentData {
    * 
    * We don't see this for the tidy test datasets such as Platinum Genomes. But in practice, we have
    * seen datasets with the same individual sequenced twice, mistakes in data conversions prior to
-   * this step, etc... So this function emits and aggregate counter of the number of variants with
-   * ambiguous calls for the same individual and also flags the particular variants in which they
-   * occur.
+   * this step, etc... So this function flags the particular variants with ambiguous calls for the
+   * same individual, and also updates the UI with a count of such variants.
    */
   public static final class FlagVariantsWithAmbiguousCallsFn extends DoFn<Variant, Variant> {
 

--- a/Java/PlatinumGenomes-variant-transformation/src/test/java/com/google/cloud/genomics/examples/TransformNonVariantSegmentDataTest.java
+++ b/Java/PlatinumGenomes-variant-transformation/src/test/java/com/google/cloud/genomics/examples/TransformNonVariantSegmentDataTest.java
@@ -1,0 +1,65 @@
+package com.google.cloud.genomics.examples;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.api.services.genomics.model.Call;
+import com.google.api.services.genomics.model.Variant;
+import com.google.cloud.dataflow.sdk.transforms.DoFnTester;
+import com.google.common.collect.ImmutableSet;
+
+@RunWith(JUnit4.class)
+public class TransformNonVariantSegmentDataTest {
+
+  @Test
+  public void testFilterCallsFn() {
+
+    DoFnTester<Variant, Variant> filterCallsFn =
+        DoFnTester.of(new TransformNonVariantSegmentData.FilterCallsFn(ImmutableSet.of("filterMeOut", 
+            "alsoFilterMeOut")));
+
+    Call call1 = new Call().setCallSetName("filterMeOut");
+    Call call2 = new Call().setCallSetName("keepMe");
+    Call call3 = new Call().setCallSetName("alsoFilterMeOut");
+    Variant inputVariant = new Variant().setCalls(Arrays.asList(call1, call2, call3));
+    
+    Variant expectedVariant = new Variant().setCalls(Arrays.asList(call2));
+    
+    Assert.assertThat(filterCallsFn.processBatch(inputVariant),
+        CoreMatchers.hasItems(expectedVariant));
+  }
+
+  @Test
+  public void testFlagVariantsWithAmbiguousCallsFn() {
+
+    DoFnTester<Variant, Variant> flagVariantsFn =
+        DoFnTester.of(new TransformNonVariantSegmentData.FlagVariantsWithAmbiguousCallsFn());
+
+    Call call1 = new Call().setCallSetName("sample1").setGenotype(Arrays.asList(0,1));
+    Call call2a = new Call().setCallSetName("sample2").setGenotype(Arrays.asList(0,1));
+    Call call2b = new Call().setCallSetName("sample2").setGenotype(Arrays.asList(-1,-1));
+    
+    Variant inputVariant = new Variant().setCalls(Arrays.asList(call1, call2a));
+    Variant ambiguousInputVariant = new Variant().setCalls(Arrays.asList(call1, call2a, call2b));
+    
+    Variant expectedVariant = new Variant().setCalls(Arrays.asList(call1, call2a))
+        .setInfo(new HashMap<String, List<String>>());
+        expectedVariant.getInfo().put(TransformNonVariantSegmentData.HAS_AMBIGUOUS_CALLS_FIELD,
+            Arrays.asList(Boolean.FALSE.toString()));
+    Variant ambiguousExpectedVariant = new Variant().setCalls(Arrays.asList(call1, call2a, call2b))
+        .setInfo(new HashMap<String, List<String>>());
+    ambiguousExpectedVariant.getInfo().put(TransformNonVariantSegmentData.HAS_AMBIGUOUS_CALLS_FIELD,
+            Arrays.asList(Boolean.TRUE.toString()));
+
+    Assert.assertThat(flagVariantsFn.processBatch(inputVariant, ambiguousInputVariant),
+        CoreMatchers.hasItems(expectedVariant, ambiguousExpectedVariant));
+  }
+
+}

--- a/Java/PlatinumGenomes-variant-transformation/src/test/java/com/google/cloud/genomics/examples/TransformNonVariantSegmentDataTest.java
+++ b/Java/PlatinumGenomes-variant-transformation/src/test/java/com/google/cloud/genomics/examples/TransformNonVariantSegmentDataTest.java
@@ -33,7 +33,7 @@ public class TransformNonVariantSegmentDataTest {
     Variant expectedVariant = new Variant().setCalls(Arrays.asList(call2));
     
     Assert.assertThat(filterCallsFn.processBatch(inputVariant),
-        CoreMatchers.hasItems(expectedVariant));
+        CoreMatchers.allOf(CoreMatchers.hasItems(expectedVariant)));
   }
 
   @Test
@@ -59,7 +59,7 @@ public class TransformNonVariantSegmentDataTest {
             Arrays.asList(Boolean.TRUE.toString()));
 
     Assert.assertThat(flagVariantsFn.processBatch(inputVariant, ambiguousInputVariant),
-        CoreMatchers.hasItems(expectedVariant, ambiguousExpectedVariant));
+        CoreMatchers.allOf(CoreMatchers.hasItems(expectedVariant, ambiguousExpectedVariant)));
   }
 
 }


### PR DESCRIPTION
Also optionally filter out particular calls sets.

For more background on the purpose of this pipeline, see https://github.com/googlegenomics/codelabs/tree/master/Java/PlatinumGenomes-variant-transformation